### PR TITLE
Latitude and longitude get for non-existant values returns None

### DIFF
--- a/address/models.py
+++ b/address/models.py
@@ -161,8 +161,8 @@ class AddressField(models.ForeignKey):
             postal_code = value.get('postal_code', '')
             street_address = value.get('street_address', '')
             formatted = value.get('formatted', '')
-            latitude = value.get('latitude', '')
-            longitude = value.get('longitude', '')
+            latitude = value.get('latitude', None)
+            longitude = value.get('longitude', None)
 
             # Handle the country.
             try:


### PR DESCRIPTION
Django is trying to convert the empty strings to floats and failing if latitude and longitude are not provided.  Using None instead of an empty string seems to provide better behavior.
