### PR TITLE
Move address input initialize to function so it can be called if new …

### DIFF
--- a/address/static/address/css/address.css
+++ b/address/static/address/css/address.css
@@ -1,0 +1,3 @@
+.pac-container {
+    z-index: 1051 !important;
+}

--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -1,42 +1,49 @@
-function django_input_address_setup() {
-    $('input.address').each(function() {
-        var self = $(this);
-        //Skip if already setup
-        if (self.data('django_input_address_setup')) {
-            return true;
-        }
+(function($) {
 
-        var cmps = $('#' + self.attr('name') + '_components');
-        var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
-        self.geocomplete({
-            details: cmps,
-            detailsAttribute: 'data-geo'
-        }).change(function() {
-            if (self.val() != fmtd.val()) {
-                var cmp_names = [
-                    'country',
-                    'country_code',
-                    'locality',
-                    'postal_code',
-                    'route',
-                    'street_number',
-                    'state',
-                    'state_code',
-                    'formatted',
-                    'latitude',
-                    'longitude'
-                ];
-                for (var ii = 0; ii < cmp_names.length; ++ii)
-                    $('input[name="' + self.attr('name') + '_' + cmp_names[ii] + '"]').val('');
+    $.fn.djangoAddressInput = function() {
+
+        this.each(function() {
+            var self = $(this);
+            //Skip if already setup
+            if (self.data('django_input_address_setup')) {
+                return true;
             }
+
+            var cmps = $('#' + self.attr('name') + '_components');
+            var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
+            self.geocomplete({
+                details: cmps,
+                detailsAttribute: 'data-geo'
+            }).change(function() {
+                if (self.val() != fmtd.val()) {
+                    var cmp_names = [
+                        'country',
+                        'country_code',
+                        'locality',
+                        'postal_code',
+                        'route',
+                        'street_number',
+                        'state',
+                        'state_code',
+                        'formatted',
+                        'latitude',
+                        'longitude'
+                    ];
+                    for (var ii = 0; ii < cmp_names.length; ++ii)
+                        $('input[name="' + self.attr('name') + '_' + cmp_names[ii] + '"]').val('');
+                }
+            });
+
+            //Add data so element will not be setup again
+            self.data('django_input_address_setup', true);
         });
 
-        //Add data so element will not be setup again
-        self.data('django_input_address_setup', true);
-    });
-}
+        return this;
 
+    };
+
+}(jQuery));
 
 $(function() {
-	django_input_address_setup();
+	$('input.address').djangoAddressInput();
 });

--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -1,19 +1,42 @@
-$(function(){
-    $('input.address').each(function(){
+function django_input_address_setup() {
+    $('input.address').each(function() {
         var self = $(this);
-	var cmps = $('#' + self.attr('name') + '_components');
-	var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
+        //Skip if already setup
+        if (self.data('django_input_address_setup')) {
+            return true;
+        }
+
+        var cmps = $('#' + self.attr('name') + '_components');
+        var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
         self.geocomplete({
             details: cmps,
             detailsAttribute: 'data-geo'
-        }).change(function(){
-	    if(self.val() != fmtd.val()) {
-		var cmp_names = ['country', 'country_code', 'locality', 'postal_code',
-				 'route', 'street_number', 'state', 'state_code',
-				 'formatted', 'latitude', 'longitude'];
-		for(var ii = 0; ii < cmp_names.length; ++ii)
-		    $('input[name="' + self.attr('name') + '_' + cmp_names[ii] + '"]').val('');
-	    }
-	});
+        }).change(function() {
+            if (self.val() != fmtd.val()) {
+                var cmp_names = [
+                    'country',
+                    'country_code',
+                    'locality',
+                    'postal_code',
+                    'route',
+                    'street_number',
+                    'state',
+                    'state_code',
+                    'formatted',
+                    'latitude',
+                    'longitude'
+                ];
+                for (var ii = 0; ii < cmp_names.length; ++ii)
+                    $('input[name="' + self.attr('name') + '_' + cmp_names[ii] + '"]').val('');
+            }
+        });
+
+        //Add data so element will not be setup again
+        self.data('django_input_address_setup', true);
     });
+}
+
+
+$(function() {
+	django_input_address_setup();
 });


### PR DESCRIPTION
…elements are added

I used django address with bootstrap modals that were loaded after the initial page load. 

If you call the function `django_input_address_setup()` like this:

```
$(your modal).on('shown.bs.modal', function(event) {
    django_input_address_setup();
});
```

The new input should get the address. 
address/css/address.css also needs to be included for z-index
