### PR TITLE
AppConfig & Unique app label

### DIFF
--- a/address/__init__.py
+++ b/address/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "address.apps.DjAddressConfig"

--- a/address/apps.py
+++ b/address/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class DjAddressConfig(AppConfig):
-    name = "dj_address"
+    name = "address"
     label = "dj_address"
     verbose_name = "Django Address"

--- a/address/apps.py
+++ b/address/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class DjAddressConfig(AppConfig):
+    name = "dj_address"
+    label = "dj_address"
+    verbose_name = "Django Address"

--- a/address/migrations/0001_initial.py
+++ b/address/migrations/0001_initial.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=165, blank=True)),
                 ('code', models.CharField(max_length=3, blank=True)),
-                ('country', models.ForeignKey(related_name='states', to='address.Country')),
+                ('country', models.ForeignKey(related_name='states', to='dj_address.Country')),
             ],
             options={
                 'ordering': ('country', 'name'),
@@ -65,12 +65,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='locality',
             name='state',
-            field=models.ForeignKey(related_name='localities', to='address.State'),
+            field=models.ForeignKey(related_name='localities', to='dj_address.State'),
         ),
         migrations.AddField(
             model_name='address',
             name='locality',
-            field=models.ForeignKey(related_name='addresses', blank=True, to='address.Locality', null=True),
+            field=models.ForeignKey(related_name='addresses', blank=True, to='dj_address.Locality', null=True),
         ),
         migrations.AlterUniqueTogether(
             name='state',

--- a/address/migrations/0002_create_component.py
+++ b/address/migrations/0002_create_component.py
@@ -8,7 +8,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('address', '0001_initial'),
+        ('dj_address', '0001_initial'),
     ]
 
     operations = [
@@ -19,13 +19,13 @@ class Migration(migrations.Migration):
                 ('kind', models.BigIntegerField()),
                 ('long_name', models.CharField(blank=True, max_length=256)),
                 ('short_name', models.CharField(blank=True, max_length=256)),
-                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='address.Component')),
+                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='dj_address.Component')),
             ],
         ),
         migrations.AddField(
             model_name='address',
             name='components',
-            field=models.ManyToManyField(blank=True, to='address.Component'),
+            field=models.ManyToManyField(blank=True, to='dj_address.Component'),
         ),
         migrations.AddField(
             model_name='address',

--- a/address/migrations/0003_convert_addresses.py
+++ b/address/migrations/0003_convert_addresses.py
@@ -11,8 +11,8 @@ from address.models import to_python
 
 def convert_addresses(apps, schema_editor):
     geolocator = GoogleV3(api_key=getattr(settings, 'GOOGLE_API_KEY', None), timeout=60)
-    address_model = apps.get_model('address.address')
-    component_model = apps.get_model('address.component')
+    address_model = apps.get_model('dj_address.address')
+    component_model = apps.get_model('dj_address.component')
     for obj in address_model.objects.all():
         orig_addr = obj.raw if obj.raw else obj.formatted
         addr = to_python(orig_addr,
@@ -39,7 +39,7 @@ def convert_addresses(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('address', '0002_create_component'),
+        ('dj_address', '0002_create_component'),
     ]
 
     operations = [

--- a/address/migrations/0004_finalise_version_2.py
+++ b/address/migrations/0004_finalise_version_2.py
@@ -8,7 +8,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('address', '0003_convert_addresses'),
+        ('dj_address', '0003_convert_addresses'),
     ]
 
     operations = [

--- a/address/migrations/0005_address_consistent.py
+++ b/address/migrations/0005_address_consistent.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('address', '0004_finalise_version_2'),
+        ('dj_address', '0004_finalise_version_2'),
     ]
 
     operations = [

--- a/address/models.py
+++ b/address/models.py
@@ -228,7 +228,7 @@ def lookup(address, instance=None, address_model=None, component_model=None, geo
 class Component(models.Model):
     """An address component."""
 
-    parent     = models.ForeignKey('address.Component', related_name='children', blank=True, null=True)
+    parent     = models.ForeignKey('dj_address.Component', related_name='children', blank=True, null=True)
     kind       = models.BigIntegerField()
     long_name  = models.CharField(max_length=256, blank=True)
     short_name = models.CharField(max_length=256, blank=True)
@@ -359,13 +359,13 @@ class AddressField(models.ForeignKey):
     """An address model field.
 
     The address is stored as a foreign-key; AddressField inherits from
-    ForeignKey but forces the related field to be `address.Address`.
+    ForeignKey but forces the related field to be `dj_address.Address`.
     """
 
     description = 'An address'
 
     def __init__(self, **kwargs):
-        kwargs['to'] = 'address.Address'
+        kwargs['to'] = 'dj_address.Address'
         super(AddressField, self).__init__(**kwargs)
 
     def contribute_to_class(self, cls, name, virtual_only=False):

--- a/address/operations.py
+++ b/address/operations.py
@@ -32,6 +32,6 @@ class ConvertAddresses(migrations.RunPython):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         if router.allow_migrate(schema_editor.connection.alias, app_label, **self.hints):
             self.geolocator = GoogleV3(api_key=getattr(settings, 'GOOGLE_API_KEY', None), timeout=60)
-            self.address_model = from_state.apps.get_model('address.address')
-            self.component_model = from_state.apps.get_model('address.component')
+            self.address_model = from_state.apps.get_model('dj_address.address')
+            self.component_model = from_state.apps.get_model('dj_address.component')
             self.code(from_state.apps, schema_editor, self.geolocate)


### PR DESCRIPTION
I had the following error using django-oscar (an app named _address_ inside) and django-address:

`django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: address`

I thought it might be appropriate to add an AppConfig. But choosing a more specific name is maybe a better solution to fix this problem.
