### PR TITLE
Add tox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 db.sqlite3
 environ/
 examples/example_site/env
+.eggs/
+.tox/

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,10 @@
+#! /usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'db.sqlite3',
+    }
+}
+
+INSTALLED_APPS = [
+    'address',
+]
+
+SECRET_KEY = 'NONE'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    {py27,py32,py33,py34,py35}-django18
+    {py27,py34,py35}-django19
+
+[testenv]
+commands = python manage.py test
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10


### PR DESCRIPTION
This PR adds a [tox.ini](https://tox.readthedocs.org/en/latest/) so that we can easily test `django-address` with multiple versions of python or django.
