### PR TITLE
Correct subclass constructor signature

### DIFF
--- a/address/models.py
+++ b/address/models.py
@@ -284,7 +284,7 @@ class AddressDescriptor(ForwardManyToOneDescriptor):
 class AddressField(models.ForeignKey):
     description = 'An address'
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         kwargs['to'] = 'address.Address'
         super(AddressField, self).__init__(**kwargs)
 


### PR DESCRIPTION
As a subclass of ForeignKey, AddressField should implement a
constructor with the same signature as ForeignKey, such that if code
wishes to treat AddressField as an instance of a ForeignKey, it can
instantiate it that way. This is important for other libraries that
handle FKs. Even though we'll ignore the *args passed to AddressField,
we should add it to the signature to keep it consistent with ForeignKey.
