### PR TITLE
Add GOOGLE_API_KEY if it exists to the google maps api url.

### DIFF
--- a/address/forms.py
+++ b/address/forms.py
@@ -2,6 +2,7 @@ from django import forms
 # from uni_form.helpers import *
 from django.utils.safestring import mark_safe
 from .models import Address, to_python
+from django.conf import settings
 
 import logging
 logger = logging.getLogger(__name__)
@@ -24,11 +25,20 @@ class AddressWidget(forms.TextInput):
                   ('formatted', 'formatted_address'),
                   ('latitude', 'lat'), ('longitude', 'lng')]
 
-    class Media:
-        js = (
-              'https://maps.googleapis.com/maps/api/js?libraries=places&sensor=false',
-              'js/jquery.geocomplete.min.js',
-              'address/js/address.js')
+    def _media(self):
+        maps_api = 'https://maps.googleapis.com/maps/api/js'
+        query_parms = '?libraries=places&sensor=false'
+
+        if settings.GOOGLE_API_KEY:
+            query_parms += '&key={}'.format(settings.GOOGLE_API_KEY)
+
+        return forms.Media(js=(
+            'js/jquery.min.js',
+            'address/js/jquery.geocomplete.js',
+            'address/js/address.js',
+            maps_api + query_parms))
+
+    media = property(_media)
 
     def __init__(self, *args, **kwargs):
         attrs = kwargs.get('attrs', {})

--- a/address/forms.py
+++ b/address/forms.py
@@ -29,7 +29,7 @@ class AddressWidget(forms.TextInput):
         maps_api = 'https://maps.googleapis.com/maps/api/js'
         query_parms = '?libraries=places&sensor=false'
 
-        if settings.GOOGLE_API_KEY:
+        if getattr(settings, 'GOOGLE_API_KEY', None) is not None:
             query_parms += '&key={}'.format(settings.GOOGLE_API_KEY)
 
         return forms.Media(js=(


### PR DESCRIPTION
Google now requires a 'key' parameter when querying its maps API. This commit
appends the query parameter if it exists in settings.
