### PR TITLE
Add workaround for cases where locality isn't populated but sublocality is

### DIFF
--- a/address/forms.py
+++ b/address/forms.py
@@ -17,8 +17,9 @@ __all__ = ['AddressWidget', 'AddressField']
 
 class AddressWidget(forms.TextInput):
     components = [('country', 'country'), ('country_code', 'country_short'),
-                  ('locality', 'locality'), ('postal_code', 'postal_code'),
-                  ('route', 'route'), ('street_number', 'street_number'),
+                  ('locality', 'locality'), ('sublocality', 'sublocality'),
+                  ('postal_code', 'postal_code'), ('route', 'route'),
+                  ('street_number', 'street_number'),
                   ('state', 'administrative_area_level_1'),
                   ('state_code', 'administrative_area_level_1_short'),
                   ('formatted', 'formatted_address'),

--- a/address/models.py
+++ b/address/models.py
@@ -29,6 +29,7 @@ def _to_python(value):
     state = value.get('state', '')
     state_code = value.get('state_code', '')
     locality = value.get('locality', '')
+    sublocality = value.get('sublocality', '')
     postal_code = value.get('postal_code', '')
     street_number = value.get('street_number', '')
     route = value.get('route', '')
@@ -39,6 +40,10 @@ def _to_python(value):
     # If there is no value (empty raw) then return None.
     if not raw:
         return None
+
+    # Fix issue with NYC boroughs (https://code.google.com/p/gmaps-api-issues/issues/detail?id=635)
+    if not locality and sublocality:
+        locality = sublocality
 
     # If we have an inconsistent set of value bail out now.
     if (country or state or locality) and not (country and state and locality):

--- a/address/tests/test_forms.py
+++ b/address/tests/test_forms.py
@@ -34,7 +34,7 @@ class AddressFieldTestCase(TestCase):
         self.assertEqual(self.field.to_python({'latitude': ''}), None)
         self.assertEqual(self.field.to_python({'longitude': ''}), None)
 
-    def test_to_pyton_no_locality(self):
+    def test_to_python_no_locality(self):
         input = {
             'country': 'United States',
             'country_code': 'US',

--- a/address/tests/test_forms.py
+++ b/address/tests/test_forms.py
@@ -34,6 +34,22 @@ class AddressFieldTestCase(TestCase):
         self.assertEqual(self.field.to_python({'latitude': ''}), None)
         self.assertEqual(self.field.to_python({'longitude': ''}), None)
 
+    def test_to_pyton_no_locality(self):
+        input = {
+            'country': 'United States',
+            'country_code': 'US',
+            'state': 'New York',
+            'state_code': 'NY',
+            'locality': '',
+            'sublocality': 'Brooklyn',
+            'postal_code': '11201',
+            'route': 'Joralemon St',
+            'street_number': '209',
+            'raw': '209 Joralemon Street, Brooklyn, NY, United States'
+        }
+        res = self.field.to_python(input)
+        self.assertEqual(res.locality.name, 'Brooklyn')
+
     # TODO: Fix
     # def test_to_python_empty_state(self):
     #     val = self.field.to_python(self.missing_state)


### PR DESCRIPTION
There's an issue with the Google Maps API ([635](https://code.google.com/p/gmaps-api-issues/issues/detail?id=635)) that causes this library to not work for addresses in the outer boroughs of NYC (i.e. Brooklyn).  The issue has been open and acknowledged by Google since 2008 so seems unlikely to be fixed soon.  In these cases, the geocoding data includes a sublocality but no locality so the suggested workaround is to use sublocality in place of locality.  This patch implements that workaround for this library.
