### PR TITLE
Modification of google maps import URL

### DIFF
--- a/address/forms.py
+++ b/address/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 # from uni_form.helpers import *
 from django.utils.safestring import mark_safe
+from django.conf import settings
 from .models import Address, to_python
 
 import logging
@@ -26,7 +27,7 @@ class AddressWidget(forms.TextInput):
 
     class Media:
         js = (
-              'https://maps.googleapis.com/maps/api/js?libraries=places&sensor=false',
+              'https://maps.googleapis.com/maps/api/js?key='+GOOGLE_API_KEY+'libraries=places&sensor=false',
               'js/jquery.geocomplete.min.js',
               'address/js/address.js')
 


### PR DESCRIPTION
Hi,

I had trouble having your module work. It produces the following error :
Google Maps API error: Google Maps API error: MissingKeyMapError

This is due to the absence of the api key in the link used to download maps api.

I suggest this modification, which will read a GOOGLE_API_KEY value defined in settings.py

Cheers,
Chloé