### PR TITLE
Add missing 'on_delete' to address/models.py for Django 2.0

### DIFF
--- a/address/models.py
+++ b/address/models.py
@@ -307,6 +307,7 @@ class AddressField(models.ForeignKey):
 
     def __init__(self, *args, **kwargs):
         kwargs['to'] = 'address.Address'
+        kwargs['on_delete'] = 'models.CASCADE'
         super(AddressField, self).__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name, virtual_only=False):


### PR DESCRIPTION
Seems like this issue was fixed at one point based on the items in the "Issues" section but I attempted an installation in a Django 2.0 environment and the issue hadn't been fixed.