### PR TITLE
Warn when there is no GOOGLE_API_KEY defined

### DIFF
--- a/address/forms.py
+++ b/address/forms.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ['AddressWidget', 'AddressField']
 
-if not settings.GOOGLE_API_KEY:
+if not hasattr(settings, 'GOOGLE_API_KEY') or not settings.GOOGLE_API_KEY:
     raise ImproperlyConfigured("GOOGLE_API_KEY is not configured in settings.py")
 
 

--- a/address/forms.py
+++ b/address/forms.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import warnings
 
 from django import forms
 from django.conf import settings
@@ -19,7 +20,8 @@ logger = logging.getLogger(__name__)
 __all__ = ['AddressWidget', 'AddressField']
 
 if not hasattr(settings, 'GOOGLE_API_KEY') or not settings.GOOGLE_API_KEY:
-    raise ImproperlyConfigured("GOOGLE_API_KEY is not configured in settings.py")
+    msg = "GOOGLE_API_KEY is not configured in settings.py"
+    warnings.warn(msg, RuntimeWarning)
 
 
 class AddressField(forms.ModelChoiceField):

--- a/address/widgets.py
+++ b/address/widgets.py
@@ -28,7 +28,7 @@ class AddressWidget(forms.TextInput):
     class Media:
         """Media defined as a dynamic property instead of an inner class."""
         js = [
-            'https://maps.googleapis.com/maps/api/js?libraries=places&key=%s' % settings.GOOGLE_API_KEY,
+            'https://maps.googleapis.com/maps/api/js?libraries=places&key=%s' % settings.GOOGLE_API_KEY if hasattr(settings, 'GOOGLE_API_KEY') else '',
             'js/jquery.geocomplete.min.js',
             'address/js/address.js',
         ]


### PR DESCRIPTION
Google's Map APIs need an API key to work.  For that reason this package will throw an exception at runtime if there is no `GOOGLE_API_KEY` defined in `settings.py`.  I propose that the package throws a warning instead.  Forcing a `GOOGLE_API_KEY` definition prevents the ability to extend the forms.py `AddressField`.  This is awkward if you want to use an API key that is held inside your database (or any other dynamic assignment).