### PR TITLE
remove python_2_unicode_compatible that no longer exists in django 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ## Installation
 
-Previously a patch for Django was required to make this app work, but as
-of 1.7 the patch is no longer needed. Installation is now done as per
-usual. The package is installed with:
+django-address requires python 3.3+ as of version 0.3.0. The package is installed with:
 
 ```bash
 pip install django-address

--- a/address/models.py
+++ b/address/models.py
@@ -4,7 +4,6 @@ import sys
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.fields.related import ForeignObject
-from django.utils.encoding import python_2_unicode_compatible
 
 try:
     from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
@@ -161,7 +160,6 @@ def to_python(value):
 ##
 
 
-@python_2_unicode_compatible
 class Country(models.Model):
     name = models.CharField(max_length=40, unique=True, blank=True)
     code = models.CharField(max_length=2, blank=True)  # not unique as there are duplicates (IT)
@@ -178,7 +176,6 @@ class Country(models.Model):
 ##
 
 
-@python_2_unicode_compatible
 class State(models.Model):
     name = models.CharField(max_length=165, blank=True)
     code = models.CharField(max_length=3, blank=True)
@@ -204,7 +201,6 @@ class State(models.Model):
 ##
 
 
-@python_2_unicode_compatible
 class Locality(models.Model):
     name = models.CharField(max_length=165, blank=True)
     postal_code = models.CharField(max_length=10, blank=True)
@@ -234,7 +230,6 @@ class Locality(models.Model):
 ##
 
 
-@python_2_unicode_compatible
 class Address(models.Model):
     street_number = models.CharField(max_length=20, blank=True)
     route = models.CharField(max_length=100, blank=True)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.2.1'
+version = '0.3.0'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")
@@ -26,17 +26,18 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.7',
         'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3 :: Only',
     ],
     license='BSD',
 


### PR DESCRIPTION
fixes #91

this arguably breaks python 2 in some ways.  I can spend a bit more time on this if you'd prefer to maintain python 2 support, even though it is beyond its supported lifetime.