### PR TITLE
update python_2_unicode_compatible

### DIFF
--- a/address/models.py
+++ b/address/models.py
@@ -4,7 +4,7 @@ import sys
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.fields.related import ForeignObject
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 try:
     from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor

--- a/example_site/requirements.txt
+++ b/example_site/requirements.txt
@@ -1,1 +1,2 @@
 django
+six

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.2.1'
+version = '0.2.2'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={'': ['*.txt', '*.js', '*.html', '*.*']},
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'six'],
     zip_safe=False,
 
 )


### PR DESCRIPTION
This is just an alternative to the last pull request, I wasn't sure it it was better to remove python2 support entirely (people shouldn't use it, but you know how that goes) or patch it with six