### PR TITLE
Update on_delete policy

### DIFF
--- a/address/models.py
+++ b/address/models.py
@@ -301,7 +301,9 @@ class AddressField(models.ForeignKey):
 
     def __init__(self, *args, **kwargs):
         kwargs['to'] = 'address.Address'
-        kwargs['on_delete'] = models.CASCADE
+        # The address should be set to null when deleted if the relationship could be null
+        default_on_delete = models.SET_NULL if kwargs.get('null', False) else models.CASCADE
+        kwargs['on_delete'] = kwargs.get('on_delete', default_on_delete)
         super(AddressField, self).__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name, virtual_only=False):


### PR DESCRIPTION
The address should be set to null when deleted if the relationship could be null.
Also, if on_delete is defined on the field, it shouldn't be overridden in __init__