### PR TITLE
correct search error in admin page

### DIFF
--- a/address/admin.py
+++ b/address/admin.py
@@ -32,5 +32,5 @@ class LocalityAdmin(admin.ModelAdmin):
 
 @admin.register(Address)
 class AddressAdmin(admin.ModelAdmin):
-    search_fields = ('name',)
+    search_fields = ('raw', 'route')
     list_filter = (UnidentifiedListFilter,)


### PR DESCRIPTION
When searching address in the Django admin page, it's getting error.  Here is the fix
<img width="993" alt="Screen Shot 2021-06-21 at 9 07 58 AM" src="https://user-images.githubusercontent.com/8908273/122794021-a917a000-d270-11eb-84c2-643369091067.png">
