### PR TITLE
Use __str__ logic for serializing formatted value if it is missing

### DIFF
--- a/address/apps.py
+++ b/address/apps.py
@@ -7,3 +7,6 @@ class AddressConfig(AppConfig):
     """
 
     name = "address"
+
+    def ready(self):
+        import address.signals

--- a/address/models.py
+++ b/address/models.py
@@ -94,7 +94,7 @@ def _to_python(value):
         else:
             address_obj = Address.objects.get(street_number=street_number, route=route, locality=locality_obj)
     except Address.DoesNotExist:
-        address_obj = Address(
+        address_obj = Address.objects.create(
             street_number=street_number,
             route=route,
             raw=raw,
@@ -103,15 +103,6 @@ def _to_python(value):
             latitude=latitude,
             longitude=longitude,
         )
-
-        # If "formatted" is empty try to construct it from other values.
-        if not address_obj.formatted:
-            address_obj.formatted = str(address_obj)
-
-        # Need to save.
-        address_obj.save()
-
-    # Done.
     return address_obj
 
 

--- a/address/signals.py
+++ b/address/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from address.models import Address
+
+
+@receiver(pre_save, sender=Address)
+def populate_formatted(_sender, instance, **_kwargs):
+    """If "formatted" is empty try to construct it from other values."""
+    if not instance.formatted:
+        instance.formatted = str(instance)

--- a/address/tests/test_models.py
+++ b/address/tests/test_models.py
@@ -141,6 +141,10 @@ class AddressTestCase(TestCase):
         obj = Address.objects.create()
         self.assertRaises(ValidationError, obj.clean)
 
+    def test_formatted_autopopulation(self):
+        self.assertEqual(self.ad2.formatted, str(self.ad2), self.ad2.formatted)
+        self.assertEqual(str(Address.objects.get(id=self.ad1.id)), self.ad1.formatted)
+
     def test_ordering(self):
         qs = Address.objects.all()
         self.assertEqual(qs.count(), 4)
@@ -159,6 +163,9 @@ class AddressTestCase(TestCase):
     def test_unicode(self):
         self.assertEqual(unicode(self.ad1), u"1 Some Street, Melbourne, Victoria 3000, Australia")
         self.assertEqual(unicode(self.ad_empty), u"Northcote, Victoria 3070, Australia")
+
+    def test_auto_formatted(self):
+        self.assertEqual(str(self.ad1), self.ad1.formatted, self.ad1.formatted)
 
 
 class AddressFieldTestCase(TestCase):


### PR DESCRIPTION
The widget for this app, in `address.widgets.AddressWidget.render`, prepopulates the address form with the value of `address.formatted` if it exists, but otherwise it stays blank.

However, an address can be created with just `address.models.Address.create(address="north pole")`, and this
populates the `Address.raw` value and nothing else. So making a widget using an address like that as its instance / initial value results in a weird state where the widget was created correctly, but there is no initial value in the widget.

The `__str__` method of the Address model contains logic that addresses this: it returns the `formatted` value if one exists, otherwise it tries to construct one from the `locality` fields, otherwise it falls back to the `raw` value. Using this method to populate the `formatted` value in `to_dict` fixes this problem of the widget.

<img width="897" alt="Screen Shot 2021-09-04 at 11 12 41 AM" src="https://user-images.githubusercontent.com/12753722/132105819-093a5758-802d-4f19-9039-0e04202423e5.png">
