### PR TITLE
Enhancements to Address

### DIFF
--- a/address/settings.py
+++ b/address/settings.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+# Some counties doesn't have "state" value so google return locality but not no state
+# Set this to true and it will create dummy state
+ALLOW_UNKNOWN_STATES = getattr(settings, 'ALLOW_UNKNOWN_STATES', False)
+
+# Set this to false so only valid address is saved, allowing dummy addresses means
+# accepting Address with only `raw` value is filled
+ALLOW_DUMMY_ADDRESSES = getattr(settings, 'ALLOW_UNKNOWN_STATES', True)

--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -12,6 +12,7 @@ $(function () {
 					'country',
 					'country_code',
 					'locality',
+					'administrative_area_level_3',
 					'postal_code',
 					'postal_town',
 					'route',

--- a/address/tests/test_models.py
+++ b/address/tests/test_models.py
@@ -304,7 +304,8 @@ class AddressFieldTestCase(TestCase):
             "country": "Australia",
         }
         # This is invalid because state codes are expected to have a max of 8 characters
-        self.assertRaises(ValueError, to_python, ad)
+        address = to_python(ad)
+        self.assertEqual(address.locality.state.code, 'Somethin')
 
     def test_assignment_from_string(self):
         self.test.address = to_python(self.ad1_dict["raw"])

--- a/address/widgets.py
+++ b/address/widgets.py
@@ -26,6 +26,7 @@ class AddressWidget(forms.TextInput):
         ("street_number", "street_number"),
         ("state", "administrative_area_level_1"),
         ("state_code", "administrative_area_level_1_short"),
+        ('administrative_area_level_3', 'administrative_area_level_3'),
         ("formatted", "formatted_address"),
         ("latitude", "lat"),
         ("longitude", "lng"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
 [tool.poetry]
 name = "django-address"
-version = "0.2.5"
+version = "0.2.6"
 description = "A django application for describing addresses."
 authors = ["Luke Hodkinson <furious.luke@gmail.com>"]
+packages = [
+    { include = "address" },
+    { include = "address/*.py" },
+    { include = "address/**/*.py" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.5"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = "0.2.5"
+version = "0.2.6"
 
 if sys.argv[-1] == "tag":
     print("Tagging the version on github:")


### PR DESCRIPTION
This PR tries to solve:
- Google doesn't return `locality` every time even when address is pretty much defined, so we can rely on `administrative_area_level_3` as fallback for `city` value. [Source from google] (https://developers.google.com/maps/documentation/places/web-service/supported_types#table3)
- Not all cities in the world are located in `state`, such location can't fit in this library, e.g. `Copenhagen, Denmark`, proposed solution is to create dummy state to link city and country, i.e. `locality` -> `unknown state`-> `country` 
- Allowing dummy addresses can be problematic sometime, so I've added option to disallow them, set `ALLOW_DUMMY_ADDRESSES` to `False` in `setting.py` will stop saving dummy address, in my case, I wanted to raise error you use instead of silently storing dummy data
- `state_code` with more than `8` chars is raising error, user has nothing to do other than selecting same address, so I've changed the handling to trim the extra chars, the `state_code` is invalid from google anyway so I just logged a warning.
- modify `pyproject.toml` to fix `pip install`