### PR TITLE
Fix RemovedInDjango41Warning on `default_app_config`

### DIFF
--- a/address/__init__.py
+++ b/address/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "address.apps.AddressConfig"
+import django
+
+if django.VERSION < (3, 2):
+  default_app_config = "address.apps.AddressConfig"


### PR DESCRIPTION
[Since Django 3.2](https://code.djangoproject.com/ticket/31180
), the property has been deprecated as it is automatically detected by Django. Currently when `django-address` is loaded into a Django 3.2+ project, it throws deprecation warnings:

```
django.utils.deprecation.RemovedInDjango41Warning: 'address' defines default_app_config = 'address.apps.AddressConfig'. Django now detects this configuration automatically. You can remove default_app_config
```

The pattern in this PR can be found in other libraries that need to support wide ranges of Django versions:
https://github.com/revsys/django-health-check/blob/master/health_check/db/__init__.py

